### PR TITLE
add color for the MSWin32 platform

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -89,6 +89,7 @@ normal_form = numify
 replacer = replace_with_blank
 
 [AutoPrereqs / @Author::KENTNL/AutoPrereqs]
+skips = ^Win32::Console::ANSI$
 
 [Prereqs / @Author::KENTNL/BundleDevelSuggests]
 -phase = develop

--- a/dist.ini.meta
+++ b/dist.ini.meta
@@ -18,5 +18,6 @@ bumpversions      = 1
 srcreadme         = mkdn
 twitter_extra_hash_tags = #distzilla
 ; auto_prereqs_skip = File::Find
+auto_prereqs_skip = ^Win32::Console::ANSI$
 
 [Prereqs]

--- a/lib/Dist/Zilla/Plugin/Author/KENTNL/RecommendFixes.pm
+++ b/lib/Dist/Zilla/Plugin/Author/KENTNL/RecommendFixes.pm
@@ -20,7 +20,7 @@ use Generic::Assertions;
 
 with 'Dist::Zilla::Role::InstallTool';
 
-use Term::ANSIColor qw( colored );
+use Term::ANSIColor qw( colored ); () = eval { require Win32::Console::ANSI } if 'MSWin32' eq $^O;
 
 our $LOG_COLOR = 'yellow';
 


### PR DESCRIPTION
.# Discussion

Term::ANSIColor doesn't include MSWin32 support by default. And, unfortunately, it seems
that perl-porters don't want to include it (see https://rt.cpan.org/Ticket/Display.html?id=44807
@@ http://archive.is/gqB1N). So, to support the platform, Win32::Console::ANSI must be
used whenever Term::ANSIColor is loaded. It's tiresome but has a simple fix.

Adding `eval { require Win32::Console::ANSI }` after any require/use of Term::ANSIColor is
all that is needed for MSWin32 support. Since Win32::Console::ANSI can only be installed
on MSWin32 platforms, no `$^O eq 'MSWin32'` test is needed.
